### PR TITLE
Fix view:cache error from nonexistent views directory

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -20,8 +20,5 @@ class ServiceProvider extends AddonServiceProvider
     {
         // register field type
         rive::register();
-
-        // register views
-        $this->loadViewsFrom(__DIR__.'/../resources/views', 'rive');
     }
 }


### PR DESCRIPTION
## Summary
- Removes the `loadViewsFrom()` call that referenced a non-existent `resources/views` directory
- This addon uses Vue components for the CP fieldtype and has no Blade views, so the line was unnecessary boilerplate

Fixes #1

## Test plan
- [ ] Run `php artisan view:cache` - should complete without error